### PR TITLE
perf(tui): stop idle redraw loop; shimmer only on latest

### DIFF
--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -61,10 +61,43 @@ type editorComponent struct {
 	currentText            string // Store current text when navigating history
 	pasteCounter           int
 	reverted               bool
+	spinnerActive          bool
+}
+
+func (m *editorComponent) shouldAnimateSpinner() bool {
+	if m == nil || m.app == nil {
+		return false
+	}
+	if m.app.IsBusy() {
+		return true
+	}
+	if m.app.CurrentPermission.ID != "" {
+		return true
+	}
+	if m.interruptKeyInDebounce {
+		return true
+	}
+	return false
+}
+
+func (m *editorComponent) ensureSpinnerTick() tea.Cmd {
+	if !m.shouldAnimateSpinner() {
+		m.spinnerActive = false
+		return nil
+	}
+	if m.spinnerActive {
+		return nil
+	}
+	m.spinnerActive = true
+	return m.spinner.Tick
 }
 
 func (m *editorComponent) Init() tea.Cmd {
-	return tea.Batch(m.textarea.Focus(), m.spinner.Tick, tea.EnableReportFocus)
+	cmds := []tea.Cmd{m.textarea.Focus(), tea.EnableReportFocus}
+	if cmd := m.ensureSpinnerTick(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *editorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -76,6 +109,10 @@ func (m *editorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width - 4
 		return m, nil
 	case spinner.TickMsg:
+		if !m.shouldAnimateSpinner() {
+			m.spinnerActive = false
+			return m, nil
+		}
 		m.spinner, cmd = m.spinner.Update(msg)
 		return m, cmd
 	case tea.KeyPressMsg:
@@ -220,7 +257,12 @@ func (m *editorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case dialog.ThemeSelectedMsg:
 		m.textarea = updateTextareaStyles(m.textarea)
 		m.spinner = createSpinner()
-		return m, tea.Batch(m.textarea.Focus(), m.spinner.Tick)
+		m.spinnerActive = false
+		cmds := []tea.Cmd{m.textarea.Focus()}
+		if cmd := m.ensureSpinnerTick(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return m, tea.Batch(cmds...)
 	case dialog.CompletionSelectedMsg:
 		switch msg.Item.ProviderID {
 		case "commands":
@@ -333,6 +375,10 @@ func (m *editorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	m.textarea, cmd = m.textarea.Update(msg)
 	cmds = append(cmds, cmd)
+
+	if cmd := m.ensureSpinnerTick(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 
 	return m, tea.Batch(cmds...)
 }
@@ -776,6 +822,7 @@ func NewEditorComponent(app *app.App) EditorComponent {
 		interruptKeyInDebounce: false,
 		historyIndex:           -1,
 		pasteCounter:           0,
+		spinnerActive:          false,
 	}
 
 	return m

--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -103,6 +103,41 @@ type ToggleToolDetailsMsg struct{}
 type ToggleThinkingBlocksMsg struct{}
 type shimmerTickMsg struct{}
 
+func (m *messagesComponent) shouldAnimateShimmer() bool {
+	if m == nil || m.app == nil {
+		return false
+	}
+	// Only consider the latest assistant message for shimmer eligibility
+	for i := len(m.app.Messages) - 1; i >= 0; i-- {
+		msg := m.app.Messages[i]
+		if assistant, ok := msg.Info.(opencode.AssistantMessage); ok {
+			// If the last assistant ended with an abort error, do not animate
+			switch assistant.Error.AsUnion().(type) {
+			case opencode.MessageAbortedError:
+				return false
+			}
+			// If the latest assistant message is still incomplete, animate
+			if assistant.Time.Completed == 0 {
+				return true
+			}
+			// Otherwise, animate only if a tool part on this same message is pending
+			for _, p := range msg.Parts {
+				if tp, ok := p.(opencode.ToolPart); ok {
+					if tp.State.Status == opencode.ToolPartStateStatusPending {
+						return true
+					}
+				}
+			}
+			return false
+		}
+	}
+	// If a permission prompt is in-flight for this session, keep animating
+	if m.app.CurrentPermission.ID != "" && m.app.CurrentPermission.SessionID == m.app.Session.ID {
+		return true
+	}
+	return false
+}
+
 func (m *messagesComponent) Init() tea.Cmd {
 	return tea.Batch(m.viewport.Init())
 }
@@ -111,7 +146,7 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	switch msg := msg.(type) {
 	case shimmerTickMsg:
-		if !m.app.HasAnimatingWork() {
+		if !m.shouldAnimateShimmer() {
 			m.animating = false
 			return m, nil
 		}
@@ -287,8 +322,8 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.renderView())
 		}
 
-		// Start shimmer ticks if any assistant/tool is in-flight
-		if !m.animating && m.app.HasAnimatingWork() {
+		// Start shimmer ticks only for the latest in-flight assistant/tool
+		if !m.animating && m.shouldAnimateShimmer() {
 			m.animating = true
 			cmds = append(cmds, tea.Tick(90*time.Millisecond, func(t time.Time) tea.Msg { return shimmerTickMsg{} }))
 		}


### PR DESCRIPTION
## Summary
- Gate editor spinner ticks to busy/permission states to prevent idle re-renders
- Restrict shimmer to newest in-flight assistant/tool and stop on abort, keeping 90ms cadence
- Reduces CPU/heat and resolves lingering shimmer after ESC interrupts

## Why
Interactive sessions were redlining due to idle render churn and multiple shimmer loops persisting after interrupts, slowing the TUI and heating the laptop.