### PR TITLE
fix(smartypants): sanitize history to avoid provider errors on reasoning and empty content

### DIFF
--- a/packages/smartypants/src/provider/transform.ts
+++ b/packages/smartypants/src/provider/transform.ts
@@ -62,6 +62,25 @@ export namespace ProviderTransform {
     return msgs
   }
 
+  function sanitizeMessages(msgs: ModelMessage[]): ModelMessage[] {
+    const out: ModelMessage[] = []
+    for (const msg of msgs) {
+      const c: any = (msg as any).content
+      if (Array.isArray(c)) {
+        const cleaned = c.filter((p: any) => p && p.type !== "reasoning")
+        if (cleaned.length > 0) {
+          ;(msg as any).content = cleaned
+          out.push(msg)
+        }
+      } else if (typeof c === "string") {
+        if (c.trim().length > 0) out.push(msg)
+      } else {
+        out.push(msg)
+      }
+    }
+    return out
+  }
+
   export function message(msgs: ModelMessage[], providerID: string, modelID: string) {
     if (modelID.includes("claude")) {
       msgs = normalizeToolCallIds(msgs)
@@ -69,7 +88,7 @@ export namespace ProviderTransform {
     if (providerID === "anthropic" || modelID.includes("anthropic") || modelID.includes("claude")) {
       msgs = applyCaching(msgs, providerID)
     }
-
+    msgs = sanitizeMessages(msgs)
     return msgs
   }
 

--- a/packages/smartypants/src/session/message-v2.ts
+++ b/packages/smartypants/src/session/message-v2.ts
@@ -555,13 +555,7 @@ export namespace MessageV2 {
                 ]
             }
             if (part.type === "reasoning") {
-              return [
-                {
-                  type: "reasoning",
-                  text: part.text,
-                  providerMetadata: part.metadata,
-                },
-              ]
+              return []
             }
 
             return []

--- a/packages/smartypants/src/session/prompt.ts
+++ b/packages/smartypants/src/session/prompt.ts
@@ -282,16 +282,17 @@ export namespace SessionPrompt {
           ),
           ...MessageV2.toModelMessage(
             msgs.filter((m) => {
-              if (m.info.role !== "assistant" || m.info.error === undefined) {
-                return true
-              }
-              if (
-                MessageV2.AbortedError.isInstance(m.info.error) &&
-                m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
-              ) {
-                return true
-              }
-
+              if (m.info.role !== "assistant") return true
+              if (m.info.error === undefined) return true
+              const hasContentfulPart = m.parts.some((part) => {
+                if (part.type === "text") return true
+                if (part.type === "tool") {
+                  const status = (part as any).state?.status
+                  return status === "completed" || status === "error"
+                }
+                return false
+              })
+              if (MessageV2.AbortedError.isInstance(m.info.error) && hasContentfulPart) return true
               return false
             }),
           ),


### PR DESCRIPTION
## Summary
- Drop prior assistant `reasoning` parts from history passed to providers (display-only), preventing OpenAI Responses API error: item of type 'reasoning' provided without required following item.
- Filter aborted assistant messages with no contentful parts (text or completed/error tool results) so history never serializes to empty `content`, avoiding `messages.N must have non-empty content`.

## Why
Interruptions (Ctrl-C) occasionally left an assistant turn with only step markers or partial tool scaffolding; combined with replaying `reasoning` chunks, subsequent calls errored and wedged the session. This patch makes history safe while preserving visible reasoning and contentful context.

## Scope
- smartypants: provider transform + message-v2 + prompt filter
- No behavior change for UI/observability; only input sanitization to providers.

## Notes
- Typecheck OK via turborepo; no API or configuration changes.