### PR TITLE
Smarty Pants fork: Langfuse + TUI reliability + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,37 @@ OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bas
 XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
+### Smarty Pants Fork Enhancements
+
+This fork adds production-oriented observability, reliability, and UX improvements tailored for Smarty Pants. Highlights:
+
+- Langfuse Observability (Sidecar v4): End-to-end tracing wired through a lightweight Node sidecar that listens to the server’s SSE stream and emits Langfuse GENERATION/TOOL/EVENT spans.
+  - Server auto-starts the sidecar (env-gated via `OPENCODE_OBSERVE=langfuse`), and exposes an `/event` SSE feed.
+  - Session-rooted traces: One root per session; per-assistant message generations are nested for clarity.
+  - Output batching: Streaming deltas are aggregated and stored as a single generation output (no word-per-span noise).
+  - Reasoning only when present: Emits a single reasoning event only if the model returns reasoning/tokens.
+  - Canonical URLs: Finalized trace URL logged back to the server for downstream UIs.
+
+- TUI Integration:
+  - Status bar shows a Langfuse hyperlink; right-aligned near the tab strip with padding.
+  - New “/trace” slash command opens the latest trace URL directly from the TUI.
+  - Exit reliability improvements: fixes to ensure the UI and background goroutines shut down cleanly.
+
+- Server/CLI Reliability:
+  - Sidecar port fix: sidecar connects to the server’s actual bound port (works with `--port 0`).
+  - `/event` SSE stream logs connection/disconnect and publishes bus events.
+  - `run` command prints final assistant text to stdout and exits with explicit status.
+
+- Dev Experience & Guardrails:
+  - Observability is opt-in via `OPENCODE_OBSERVE` gates (`langfuse` or `langfuse-app`).
+  - Reasonable defaults for secrets/env; clean shutdown for the sidecar (OTel `sdk.shutdown()`).
+
+See commit history for detailed changes:
+- observe(sidecar): session-rooted traces, output aggregation, reasoning gating
+- server: sidecar autostart + SSE feed; port detection fixes
+- tui: status bar hyperlink, `/trace` command, clean exit behavior
+- cli: robust `run` printing + explicit exit codes
+
 ### Documentation
 
 For more info on how to configure opencode [**head over to our docs**](https://opencode.ai/docs).

--- a/packages/langfuse-sidecar/bin/sidecar.mjs
+++ b/packages/langfuse-sidecar/bin/sidecar.mjs
@@ -64,7 +64,7 @@ const pending = new Map() // messageID -> { tokens, cost, finished }
 // New: maintain session root, and per-part aggregation state
 const rootBySession = new Map() // sessionID -> root obs (span)
 const partTextLen = new Map() // partID -> last observed text length
-const reasoningObsByPart = new Map() // partID -> obs (span)
+const reasoningTextByPart = new Map() // partID -> latest text
 const reasoningPartsByMessage = new Map() // messageID -> Set(partID)
 
 function ensureSessionRoot(sessionID) {
@@ -91,7 +91,7 @@ function ensureGenerationForMessage(messageID, sessionID, meta) {
   try {
     obs.updateTrace({ sessionId: sessionID })
   } catch {}
-  g = { obs, out: "", providerID: meta?.providerID, modelID: meta?.modelID }
+  g = { obs, out: "", providerID: meta?.providerID, modelID: meta?.modelID, sessionID }
   genByMsg.set(messageID, g)
   return g
 }
@@ -101,22 +101,24 @@ async function maybeFinalize(messageID, reason) {
   const st = pending.get(messageID)
   if (!g || !st?.finished) return
   try {
-    // End any open reasoning spans for this message
-    const partIDs = reasoningPartsByMessage.get(messageID)
-    if (partIDs) {
-      for (const pid of partIDs) {
-        const ro = reasoningObsByPart.get(pid)
-        if (ro) {
-          try {
-            ro.end()
-          } catch {}
-          reasoningObsByPart.delete(pid)
+    // Aggregate any reasoning text (do not emit spans per delta)
+    let reasoningText = ""
+    {
+      const partIDs = reasoningPartsByMessage.get(messageID)
+      if (partIDs) {
+        const texts = []
+        for (const pid of partIDs) {
+          const txt = reasoningTextByPart.get(pid)
+          if (txt) texts.push(txt)
+          reasoningTextByPart.delete(pid)
+          partTextLen.delete(pid)
         }
-        partTextLen.delete(pid)
+        reasoningPartsByMessage.delete(messageID)
+        reasoningText = texts.join("\n").trim()
       }
-      reasoningPartsByMessage.delete(messageID)
     }
 
+    // Update generation with output, usage, cost, provider/model
     g.obs.update({
       output: sanitizeText(g.out || ""),
       usageDetails: {
@@ -128,13 +130,29 @@ async function maybeFinalize(messageID, reason) {
       costDetails: { totalCost: st.cost },
       metadata: { providerID: g.providerID, modelID: g.modelID },
     })
+
+    // Emit a single reasoning event only if there were reasoning tokens and text
+    if (st.tokens?.reasoning && st.tokens.reasoning > 0 && reasoningText) {
+      try {
+        const r = g.obs.startObservation("reasoning", { output: sanitizeText(reasoningText) }, { asType: "event" })
+        r.end()
+      } catch {}
+    }
+
+    // Also update the session-level trace with input/output summary
+    try {
+      const root = rootBySession.get(g.sessionID)
+      const inputText = userBySession.get(g.sessionID)?.text || ""
+      if (root) root.update({ input: inputText ? { text: sanitizeText(inputText) } : undefined, output: sanitizeText(g.out || "") })
+    } catch {}
+
     g.obs.end()
     const traceId = g.obs.traceId
     let url
     try {
       if (traceId) url = await lf.getTraceUrl(traceId)
     } catch {}
-    await log("info", "generation finalized", { messageID, traceId, url, reason })
+    await log("info", "generation finalized", { sessionID: g.sessionID, messageID, traceId, url, reason })
   } catch (e) {
     await log("error", "finalize failed", { messageID, error: String(e) })
   } finally {
@@ -245,14 +263,6 @@ async function handle(ev) {
         if (delta) {
           g.out = (g.out || "") + delta
           partTextLen.set(part.id, txt.length)
-          try {
-            const s = g.obs.startObservation(
-              "text",
-              { input: { text: sanitizeText(delta) }, metadata: { messageID: part.messageID, partID: part.id } },
-              { asType: "event" },
-            )
-            s.end()
-          } catch {}
         }
       }
       return
@@ -261,22 +271,11 @@ async function handle(ev) {
     if (part.type === "reasoning") {
       const g = genByMsg.get(part.messageID)
       if (g) {
-        let s = reasoningObsByPart.get(part.id)
-        if (!s) {
-          s = g.obs.startObservation(
-            "reasoning",
-            { metadata: { ...part.metadata, messageID: part.messageID, partID: part.id } },
-            { asType: "span" },
-          )
-          reasoningObsByPart.set(part.id, s)
-          const set = reasoningPartsByMessage.get(part.messageID) || new Set()
-          set.add(part.id)
-          reasoningPartsByMessage.set(part.messageID, set)
-        }
-        // Update span output with full accumulated text to ensure visibility
-        try {
-          s.update({ output: sanitizeText(part.text) })
-        } catch {}
+        const txt = String(part.text || "")
+        reasoningTextByPart.set(part.id, txt)
+        const set = reasoningPartsByMessage.get(part.messageID) || new Set()
+        set.add(part.id)
+        reasoningPartsByMessage.set(part.messageID, set)
       }
       return
     }
@@ -352,9 +351,7 @@ async function connectSSE(url) {
 }
 
 await log("info", "sidecar starting", { eventUrl })
-try {
-  await connectSSE(eventUrl)
-} catch (e) {
+try { await connectSSE(eventUrl); try { await sdk.shutdown() } catch {} ; process.exit(0) } catch (e) {
   await log("error", "sidecar crashed", { error: String(e) })
   process.exit(1)
 }

--- a/packages/smartypants/src/cli/cmd/run.ts
+++ b/packages/smartypants/src/cli/cmd/run.ts
@@ -166,6 +166,8 @@ export const RunCommand = cmd({
 
       let text = ""
 
+      let printed = false;
+
       Bus.subscribe(MessageV2.Event.PartUpdated, async (evt) => {
         if (evt.properties.part.sessionID !== session.id) return
         if (evt.properties.part.messageID === messageID) return
@@ -194,6 +196,7 @@ export const RunCommand = cmd({
             UI.empty()
             UI.println(UI.markdown(text))
             UI.empty()
+            printed = true;
             text = ""
             return
           }
@@ -243,7 +246,17 @@ export const RunCommand = cmd({
             text: message,
           },
         ],
+
       })
+
+      if (args.format === "default") {
+        const lastTextPart = (result.parts as any[]).filter((x:any) => x.type === "text").at(-1) as any;
+        if (!printed && lastTextPart && typeof lastTextPart.text === "string" && lastTextPart.text.trim() !== "" ) {
+          UI.empty();
+          UI.println(UI.markdown(lastTextPart.text));
+          UI.empty();
+        }
+      }
 
       const isPiped = !process.stdout.isTTY
       if (isPiped) {
@@ -254,6 +267,7 @@ export const RunCommand = cmd({
       }
       UI.empty()
       if (errorMsg) process.exit(1)
+      if (!errorMsg) process.exit(0)
     })
   },
 })

--- a/packages/smartypants/src/cli/cmd/tui.ts
+++ b/packages/smartypants/src/cli/cmd/tui.ts
@@ -111,7 +111,7 @@ export const TuiCommand = cmd({
 
         let cmd = [] as string[]
         const tui = Bun.embeddedFiles.find((item) => (item as File).name.includes("tui")) as File
-        if (tui) {
+        if (tui && !Installation.isDev()) {
           let binaryName = tui.name
           if (process.platform === "win32" && !binaryName.endsWith(".exe")) {
             binaryName += ".exe"
@@ -124,7 +124,7 @@ export const TuiCommand = cmd({
           }
           cmd = [binary]
         }
-        if (!tui) {
+        if (!tui || Installation.isDev()) {
           const dir = Bun.fileURLToPath(new URL("../../../../tui/cmd/smartypants", import.meta.url))
           let binaryName = `./dist/tui${process.platform === "win32" ? ".exe" : ""}`
           await $`go build -o ${binaryName} ./main.go`.cwd(dir)
@@ -179,8 +179,9 @@ export const TuiCommand = cmd({
             .catch(() => {})
         })()
 
-        await proc.exited
+        const code = await proc.exited
         server.stop()
+        process.exit(typeof code === "number" ? code : 0)
 
         return "done"
       })

--- a/packages/smartypants/src/server/server.ts
+++ b/packages/smartypants/src/server/server.ts
@@ -30,6 +30,8 @@ import { SessionCompaction } from "../session/compaction"
 import { SessionRevert } from "../session/revert"
 import { lazy } from "../util/lazy"
 import { InstanceBootstrap } from "../project/bootstrap"
+import path from "path"
+import fs from "fs/promises"
 
 const ERRORS = {
   400: {
@@ -1139,6 +1141,30 @@ export namespace Server {
               break
           }
 
+          // Persist Langfuse trace URL for current session (no API shape changes)
+          try {
+            if (
+              service === "langfuse.sidecar" &&
+              message === "generation finalized" &&
+              typeof extra?.["url"] === "string" &&
+              typeof extra?.["sessionID"] === "string"
+            ) {
+              const dir = path.join(Global.Path.state, "observability", "langfuse")
+              await fs.mkdir(dir, { recursive: true })
+              const payload = {
+                sessionID: extra["sessionID"],
+                traceId: extra["traceId"] ?? null,
+                url: extra["url"],
+                messageID: extra["messageID"] ?? null,
+                reason: extra["reason"] ?? null,
+                updated: Date.now(),
+              }
+              await Bun.write(path.join(dir, extra["sessionID"] + ".json"), JSON.stringify(payload, null, 2))
+            }
+          } catch (e) {
+            logger.warn("failed to persist langfuse trace url", { error: String(e) })
+          }
+
           return c.json(true)
         },
       )
@@ -1444,7 +1470,7 @@ export namespace Server {
       idleTimeout: 0,
       fetch: App().fetch,
     })
-    ensureLangfuseSidecar({ directory: Global.Path.state, port: opts.port }).catch(() => {})
+    const __p:any = (server as any).port; const __port:number = typeof __p === "number" && __p > 0 ? __p : opts.port; ensureLangfuseSidecar({ directory: Global.Path.state, port: __port }).catch(() => {})
     return server
   }
 }

--- a/packages/tui/cmd/smartypants/main.go
+++ b/packages/tui/cmd/smartypants/main.go
@@ -154,6 +154,7 @@ func main() {
 		sig := <-sigChan
 		slog.Info("Received signal, shutting down gracefully", "signal", sig)
 		tuiModel.Cleanup()
+		cancel()
 		program.Quit()
 	}()
 
@@ -164,5 +165,7 @@ func main() {
 	}
 
 	tuiModel.Cleanup()
+	cancel()
 	slog.Info("TUI exited", "result", result)
+	os.Exit(0)
 }

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -159,6 +159,7 @@ const (
 	MessagesCopyCommand             CommandName = "messages_copy"
 	MessagesUndoCommand             CommandName = "messages_undo"
 	MessagesRedoCommand             CommandName = "messages_redo"
+	TraceOpenCommand               CommandName = "trace_open"
 	AppExitCommand                  CommandName = "app_exit"
 )
 
@@ -386,6 +387,11 @@ func LoadFromConfig(config *opencode.Config, customCommands []opencode.Command) 
 			Trigger:     []string{"redo"},
 		},
 		{
+            Name:        TraceOpenCommand,
+            Description: "open latest Langfuse trace",
+            Trigger:     []string{"trace"},
+        },
+        {
 			Name:        AppExitCommand,
 			Description: "exit the app",
 			Keybindings: parseBindings("ctrl+c", "<leader>q"),

--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/charmbracelet/lipgloss/v2/compat"
 	"github.com/fsnotify/fsnotify"
+	opencode "github.com/sst/opencode-sdk-go"
 	"github.com/sst/opencode/internal/app"
 	"github.com/sst/opencode/internal/commands"
 	"github.com/sst/opencode/internal/layout"
@@ -37,9 +39,11 @@ type statusComponent struct {
 	watcher    *fsnotify.Watcher
 	done       chan struct{}
 	lastUpdate time.Time
+	lfURL      string
 }
 
 func (m *statusComponent) Init() tea.Cmd {
+	m.refreshLangfuseURL()
 	return m.startGitWatcher()
 }
 
@@ -54,6 +58,25 @@ func (m *statusComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Continue watching for changes (persistent watcher)
 		return m, m.watchForGitChanges()
+	case opencode.EventListResponseEventMessageUpdated:
+		if m.app.Session != nil && msg.Properties.Info.SessionID == m.app.Session.ID {
+			m.refreshLangfuseURL()
+		}
+		return m, nil
+	case opencode.EventListResponseEventSessionUpdated:
+		if m.app.Session != nil && msg.Properties.Info.ID == m.app.Session.ID {
+			m.refreshLangfuseURL()
+		}
+		return m, nil
+	case app.SessionSelectedMsg:
+		m.refreshLangfuseURL()
+		return m, nil
+	case app.SessionCreatedMsg:
+		m.refreshLangfuseURL()
+		return m, nil
+	case app.SessionClearedMsg:
+		m.lfURL = ""
+		return m, nil
 	}
 	return m, nil
 }
@@ -159,15 +182,28 @@ func (m *statusComponent) View() string {
 		Background(t.BackgroundPanel()).
 		Foreground(t.TextMuted())
 	agent = faintStyle.Render(key+" ") + agent
-	modeWidth := lipgloss.Width(agent)
+	modeWidth := 0
 
-	availableWidth := m.width - logoWidth - modeWidth
+	// availableWidth computed after right segment
 	branchSuffix := ""
 	if m.branch != "" {
 		branchSuffix = ":" + m.branch
 	}
 
+	// Build right segment: Langfuse link (2 spaces) next to agent
+	lfLink := ""
+	if m.lfURL != "" && m.app.Session != nil && m.app.Session.ID != "" {
+		lfLink = styles.NewStyle().Background(t.BackgroundPanel()).Render("  " + osc8(m.lfURL, "Langfuse") + "  ")
+	}
+	right := lfLink + agent
+
+	modeWidth = lipgloss.Width(right)
+	availableWidth := m.width - logoWidth - modeWidth
+
 	maxCwdWidth := availableWidth - lipgloss.Width(branchSuffix)
+	if maxCwdWidth < 10 {
+		maxCwdWidth = 10
+	}
 	cwdDisplay := m.collapsePath(m.cwd, maxCwdWidth)
 
 	if m.branch != "" && availableWidth > lipgloss.Width(cwdDisplay)+lipgloss.Width(branchSuffix) {
@@ -193,12 +229,39 @@ func (m *statusComponent) View() string {
 			View: logo + cwd,
 		},
 		layout.FlexItem{
-			View: agent,
+			View: right,
 		},
 	)
 
 	blank := styles.NewStyle().Background(t.Background()).Width(m.width).Render("")
 	return blank + "\n" + status
+}
+
+func osc8(uri, text string) string {
+	// OSC 8 hyperlink: ESC ] 8 ; ; URI ESC \ TEXT ESC ] 8 ; ; ESC \
+	return "\x1b]8;;" + uri + "\x1b\\" + text + "\x1b]8;;\x1b\\"
+}
+
+func (m *statusComponent) refreshLangfuseURL() {
+	if m.app.Session == nil || m.app.Session.ID == "" {
+		m.lfURL = ""
+		return
+	}
+	base := filepath.Dir(m.app.StatePath) // path.State
+	file := filepath.Join(base, "observability", "langfuse", m.app.Session.ID+".json")
+	b, err := os.ReadFile(file)
+	if err != nil {
+		m.lfURL = ""
+		return
+	}
+	var payload struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(b, &payload); err != nil {
+		m.lfURL = ""
+		return
+	}
+	m.lfURL = payload.URL
 }
 
 func (m *statusComponent) startGitWatcher() tea.Cmd {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -1159,6 +1161,63 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 		util.CmdHandler(commands.CommandExecutedMsg(command)),
 	}
 	switch command.Name {
+	case commands.TraceOpenCommand:
+		{
+			stateHome := os.Getenv("XDG_STATE_HOME")
+			if stateHome == "" {
+				home, _ := os.UserHomeDir()
+				stateHome = filepath.Join(home, ".local", "state")
+			}
+			dir := filepath.Join(stateHome, "opencode", "observability", "langfuse")
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				return a, toast.NewErrorToast("Langfuse state not found: " + dir)
+			}
+			var latestPath string
+			var latestTime time.Time
+			for _, e := range entries {
+				if e.IsDir() {
+					continue
+				}
+				if !strings.HasSuffix(e.Name(), ".json") {
+					continue
+				}
+				info, err := e.Info()
+				if err != nil {
+					continue
+				}
+				if info.ModTime().After(latestTime) {
+					latestTime = info.ModTime()
+					latestPath = filepath.Join(dir, e.Name())
+				}
+			}
+			if latestPath == "" {
+				return a, toast.NewInfoToast("No Langfuse traces yet")
+			}
+			b, err := os.ReadFile(latestPath)
+			if err != nil {
+				return a, toast.NewErrorToast("Failed to read trace file")
+			}
+			var payload struct { URL string `json:"url"` }
+			json.Unmarshal(b, &payload)
+			if payload.URL == "" {
+				return a, toast.NewErrorToast("No URL in trace file")
+			}
+			var openCmd *exec.Cmd
+			switch runtime.GOOS {
+			case "darwin":
+				openCmd = exec.Command("open", payload.URL)
+			case "linux":
+				openCmd = exec.Command("xdg-open", payload.URL)
+			case "windows":
+				openCmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", payload.URL)
+			default:
+				openCmd = exec.Command("open", payload.URL)
+			}
+			_ = openCmd.Start()
+			cmds = append(cmds, toast.NewInfoToast("Opening Langfuse trace"))
+		}
+
 	case commands.AppHelpCommand:
 		helpDialog := dialog.NewHelpDialog(a.app)
 		a.modal = helpDialog


### PR DESCRIPTION
## Summary
- Add 'Smarty Pants Fork Enhancements' README section
- Langfuse sidecar v4: batched output; reasoning only when present; session summary; clean shutdown
- Server: sidecar autostart on actual port; SSE/event logs
- TUI: right‑aligned Langfuse link with padding; '/trace' command; clean exit
- CLI: 'run' prints final text and exits explicitly

## Why
Make observability and UX reliable for day‑to‑day engineering and debugging.