### PR TITLE
TUI: scope permission events to active session family; eliminate cross-session churn

### DIFF
--- a/packages/tui/cmd/smartypants/main.go
+++ b/packages/tui/cmd/smartypants/main.go
@@ -136,14 +136,32 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
 
 	go func() {
-		stream := httpClient.Event.ListStreaming(ctx, opencode.EventListParams{})
+		// Stream events, scoping by project directory when available, with fallback
+		params := opencode.EventListParams{}
+		if project != nil && project.Worktree != "" {
+			params.Directory = opencode.F(project.Worktree)
+		}
+		stream := httpClient.Event.ListStreaming(ctx, params)
 		for stream.Next() {
 			evt := stream.Current().AsUnion()
 			program.Send(evt)
 		}
 		if err := stream.Err(); err != nil {
-			slog.Error("Error streaming events", "error", err)
-			program.Send(err)
+			slog.Error("Error streaming events", "scoped", params.Directory.Value != "", "error", err)
+			// Fallback to unscoped stream if scoped failed
+			if params.Directory.Value != "" {
+				stream = httpClient.Event.ListStreaming(ctx, opencode.EventListParams{})
+				for stream.Next() {
+					evt := stream.Current().AsUnion()
+					program.Send(evt)
+				}
+				if err := stream.Err(); err != nil {
+					slog.Error("Error streaming events (fallback)", "error", err)
+					program.Send(err)
+				}
+			} else {
+				program.Send(err)
+			}
 		}
 	}()
 

--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -72,7 +72,10 @@ func (m *editorComponent) shouldAnimateSpinner() bool {
 		return true
 	}
 	if m.app.CurrentPermission.ID != "" {
-		return true
+		// Only animate if the permission is for the active session (or its parent)
+		if m.app.CurrentPermission.SessionID == m.app.Session.ID || (m.app.Session.ParentID != "" && m.app.CurrentPermission.SessionID == m.app.Session.ParentID) {
+			return true
+		}
 	}
 	if m.interruptKeyInDebounce {
 		return true

--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -292,11 +292,17 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.renderView())
 		}
 	case opencode.EventListResponseEventPermissionUpdated:
-		m.tail = true
-		return m, m.renderView()
+		if msg.Properties.SessionID == m.app.Session.ID || (m.app.Session.ParentID != "" && msg.Properties.SessionID == m.app.Session.ParentID) {
+			m.tail = true
+			return m, m.renderView()
+		}
+		return m, nil
 	case opencode.EventListResponseEventPermissionReplied:
-		m.tail = true
-		return m, m.renderView()
+		if msg.Properties.SessionID == m.app.Session.ID || (m.app.Session.ParentID != "" && msg.Properties.SessionID == m.app.Session.ParentID) {
+			m.tail = true
+			return m, m.renderView()
+		}
+		return m, nil
 	case renderCompleteMsg:
 		m.partCount = msg.partCount
 		m.lineCount = msg.lineCount

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -635,21 +635,35 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case opencode.EventListResponseEventPermissionUpdated:
 		slog.Debug("permission updated", "session", msg.Properties.SessionID, "permission", msg.Properties.ID)
-		a.app.Permissions = append(a.app.Permissions, msg.Properties)
-		a.app.CurrentPermission = a.app.Permissions[0]
-		a.editor.Blur()
-	case opencode.EventListResponseEventPermissionReplied:
-		index := slices.IndexFunc(a.app.Permissions, func(p opencode.Permission) bool {
-			return p.ID == msg.Properties.PermissionID
-		})
-		if index > -1 {
-			a.app.Permissions = append(a.app.Permissions[:index], a.app.Permissions[index+1:]...)
-		}
-		if a.app.CurrentPermission.ID == msg.Properties.PermissionID {
-			if len(a.app.Permissions) > 0 {
-				a.app.CurrentPermission = a.app.Permissions[0]
+		// Only surface permission prompts for the active session (or its parent)
+		if msg.Properties.SessionID == a.app.Session.ID || (a.app.Session.ParentID != "" && msg.Properties.SessionID == a.app.Session.ParentID) {
+			// De-duplicate by permission ID; update in place if exists
+			idx := slices.IndexFunc(a.app.Permissions, func(p opencode.Permission) bool { return p.ID == msg.Properties.ID })
+			if idx > -1 {
+				a.app.Permissions[idx] = msg.Properties
 			} else {
-				a.app.CurrentPermission = opencode.Permission{}
+				a.app.Permissions = append(a.app.Permissions, msg.Properties)
+			}
+			if a.app.CurrentPermission.ID == "" {
+				a.app.CurrentPermission = a.app.Permissions[0]
+			}
+			a.editor.Blur()
+		}
+	case opencode.EventListResponseEventPermissionReplied:
+		// Only update local queue if it pertains to our active session family
+		if msg.Properties.SessionID == a.app.Session.ID || (a.app.Session.ParentID != "" && msg.Properties.SessionID == a.app.Session.ParentID) {
+			index := slices.IndexFunc(a.app.Permissions, func(p opencode.Permission) bool {
+				return p.ID == msg.Properties.PermissionID
+			})
+			if index > -1 {
+				a.app.Permissions = append(a.app.Permissions[:index], a.app.Permissions[index+1:]...)
+			}
+			if a.app.CurrentPermission.ID == msg.Properties.PermissionID {
+				if len(a.app.Permissions) > 0 {
+					a.app.CurrentPermission = a.app.Permissions[0]
+				} else {
+					a.app.CurrentPermission = opencode.Permission{}
+				}
 			}
 		}
 	case opencode.EventListResponseEventSessionError:
@@ -691,6 +705,21 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.app.Session = msg
 		a.app.Messages = messages
+
+		// Cleanup permission queue to only include entries for the active session family
+		filtered := make([]opencode.Permission, 0, len(a.app.Permissions))
+		for _, p := range a.app.Permissions {
+			if p.SessionID == a.app.Session.ID || (a.app.Session.ParentID != "" && p.SessionID == a.app.Session.ParentID) {
+				filtered = append(filtered, p)
+			}
+		}
+		a.app.Permissions = filtered
+		if len(a.app.Permissions) > 0 {
+			a.app.CurrentPermission = a.app.Permissions[0]
+		} else {
+			a.app.CurrentPermission = opencode.Permission{}
+		}
+
 		cmds = append(cmds, util.CmdHandler(app.SessionLoadedMsg{}))
 		return a, tea.Batch(cmds...)
 	case app.SessionCreatedMsg:

--- a/packages/tui/internal/util/ide.go
+++ b/packages/tui/internal/util/ide.go
@@ -28,4 +28,3 @@ func Ide() string {
 
 	return "unknown"
 }
-


### PR DESCRIPTION
## Summary
- Gate permission.updated/replied to the active session family (active or parent).
- Re-render chat and animate editor spinner only for in-scope permission events.
- De-duplicate permission queue by ID; clean queue on session switch.
- Stream events scoped by project worktree, with unscoped fallback on error.

## Motivation
Previously, the TUI treated all permission updates as relevant. That forced redraws and kept the editor spinner alive due to other sessions’ work, causing sustained background CPU and visual stutter (shimmer). This change eliminates cross-session churn without reducing responsiveness.

## Changes
- `internal/tui/tui.go`: gate permission updated/replied; dedupe queue; clear queue on SessionSelected.
- `internal/components/chat/messages.go`: re-render only for in-family permission events.
- `internal/components/chat/editor.go`: animate spinner only for in-family permissions.
- `cmd/smartypants/main.go`: scope SSE by worktree with fallback.

## Behavior
- Idle TUI stays quiet; no redraws from other sessions.
- Active session remains fully responsive for prompts/permissions/animations.

## Risk / Compatibility
- Low: confines UI updates to the viewed session’s family (active or parent). If deeper trees (grandchildren) are introduced, family scoping can be extended in a follow-up.

## Testing
- Built with `go build ./cmd/smartypants`.
- Verified that unrelated sessions’ permission events no longer trigger redraws or spinner ticks.
- Verified in-scope permission prompts behave unchanged.

## Follow-ups (optional)
- If desired, extend family to include all descendants.