### PR TITLE
ci(typecheck): resolve workspace SDK in plugin via customConditions

### DIFF
--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "preserve",
     "declaration": true,
     "moduleResolution": "bundler",
+    "customConditions": ["development"],
     "lib": ["es2022", "dom", "dom.iterable"]
   },
   "include": ["src"]


### PR DESCRIPTION
- Add "customConditions": ["development"] to packages/plugin/tsconfig.json so TypeScript resolves @smartypants-ai/sdk to src during typecheck without a build

This addresses the remaining typecheck failure observed on PR #14.
