### PR TITLE
ci(typecheck): enable development condition in app for SDK exports

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -6,6 +6,8 @@
     "jsxImportSource": "solid-js",
     "types": ["vite/client"],
     "lib": ["DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "customConditions": ["development"],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
- Add "customConditions": ["development"] and "moduleResolution": "bundler" to packages/app/tsconfig.json so TypeScript resolves @smartypants-ai/sdk exports without a build.

This fixes the remaining typecheck failures on dev.