### PR TITLE
ci(typecheck): resolve smartypants workspace imports via bundler resolution

### DIFF
--- a/packages/smartypants/tsconfig.json
+++ b/packages/smartypants/tsconfig.json
@@ -2,6 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/bun/tsconfig.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "customConditions": ["development"]
   }
 }


### PR DESCRIPTION
- Add "moduleResolution": "bundler" and "customConditions": ["development"] to packages/smartypants/tsconfig.json
- This allows TS to resolve @smartypants-ai/plugin and @smartypants-ai/sdk workspace exports during typecheck without a build.

This should clear the remaining typecheck failure on dev.