### PR TITLE
ci: skip snapshot/deploy workflows on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   deploy:
+    if: ${{ github.repository == 'sst/opencode' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   publish:
+    if: ${{ github.repository == 'sst/opencode' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Add job-level 'if: github.repository == "sst/opencode"' to snapshot.yml and deploy.yml
- Prevents fork CI failures due to missing secrets and disallowed publish/deploy

Dev CI will keep running test/typecheck/format; snapshot/deploy stay active on upstream only.