### PR TITLE
ci: disable guidelines-check on forks and make workflow valid

### DIFF
--- a/.github/workflows/guidelines-check.yml
+++ b/.github/workflows/guidelines-check.yml
@@ -1,12 +1,14 @@
 name: Guidelines Check
 
 on:
-  # Disabled - uncomment to re-enable
+  # Disabled - uncomment to re-enable PR trigger
   # pull_request_target:
   #   types: [opened, synchronize]
+  workflow_dispatch:
 
 jobs:
   check-guidelines:
+    if: ${{ github.repository == 'sst/opencode' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- Add workflow_dispatch to guidelines-check.yml so the workflow file is valid
- Add job if: github.repository == 'sst/opencode' to skip on forks

This stops failing 'guidelines-check' runs on dev pushes in this repo.