### PR TITLE
Repair: downstream/smarty (branding + Langfuse only; no engine drift)

### DIFF
--- a/packages/langfuse-sidecar/bin/sidecar.mjs
+++ b/packages/langfuse-sidecar/bin/sidecar.mjs
@@ -27,7 +27,9 @@ function sanitizeFileUrl(u) {
 
 async function initOtel() {
   const sdk = new NodeSDK({ spanProcessors: [new LangfuseSpanProcessor()] })
-  try { await Promise.resolve(sdk.start()) } catch {}
+  try {
+    await Promise.resolve(sdk.start())
+  } catch {}
 }
 
 function eventUrl() {
@@ -59,7 +61,9 @@ async function connectAndStream(url) {
 
     startActiveObservation(`opencode:${t}`, async () => {
       if (sid) {
-        try { updateActiveTrace({ sessionId: String(sid) }) } catch {}
+        try {
+          updateActiveTrace({ sessionId: String(sid) })
+        } catch {}
       }
 
       if (t === "message.part.updated" && p?.part) {
@@ -85,7 +89,11 @@ async function connectAndStream(url) {
         }
         if (part.type === "tool") {
           if (part.state.status === "pending" || part.state.status === "running") {
-            const s = startObservation(`tool:${part.tool}`, { type: "TOOL", input: part.state.input, metadata: { callID: part.callID } })
+            const s = startObservation(`tool:${part.tool}`, {
+              type: "TOOL",
+              input: part.state.input,
+              metadata: { callID: part.callID },
+            })
             toolObs.set(part.callID, s)
             return
           }
@@ -105,7 +113,11 @@ async function connectAndStream(url) {
           }
         }
         if (part.type === "text") {
-          const s = startObservation("text", { type: "EVENT", input: { text: sanitizeText(part.text) }, metadata: { messageID: part.messageID } })
+          const s = startObservation("text", {
+            type: "EVENT",
+            input: { text: sanitizeText(part.text) },
+            metadata: { messageID: part.messageID },
+          })
           s.end()
           // accumulate into either user or assistant generation
           if (sid) {
@@ -123,12 +135,20 @@ async function connectAndStream(url) {
           return
         }
         if (part.type === "reasoning") {
-          const s = startObservation("reasoning", { type: "EVENT", input: { text: sanitizeText(part.text) }, metadata: { ...part.metadata, messageID: part.messageID } })
+          const s = startObservation("reasoning", {
+            type: "EVENT",
+            input: { text: sanitizeText(part.text) },
+            metadata: { ...part.metadata, messageID: part.messageID },
+          })
           s.end()
           return
         }
         if (part.type === "file") {
-          const s = startObservation("file", { type: "EVENT", input: { mime: part.mime, filename: part.filename, url: sanitizeFileUrl(part.url) }, metadata: { messageID: part.messageID } })
+          const s = startObservation("file", {
+            type: "EVENT",
+            input: { mime: part.mime, filename: part.filename, url: sanitizeFileUrl(part.url) },
+            metadata: { messageID: part.messageID },
+          })
           s.end()
           return
         }
@@ -145,7 +165,11 @@ async function connectAndStream(url) {
             const u = userBySession.get(sid)
             inputText = u?.text
           }
-          const s = startObservation("assistant", { type: "GENERATION", input: inputText ? { text: sanitizeText(inputText) } : undefined, metadata: { providerID: info.providerID, modelID: info.modelID } })
+          const s = startObservation("assistant", {
+            type: "GENERATION",
+            input: inputText ? { text: sanitizeText(inputText) } : undefined,
+            metadata: { providerID: info.providerID, modelID: info.modelID },
+          })
           s.update({ metadata: { tokens: info.tokens, cost: info.cost } })
           genByMsg.set(info.id, { obs: s, out: "" })
           return

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -57,7 +57,9 @@ try {
             const p = evt?.properties as any
             const sid = p?.sessionID || p?.info?.sessionID || p?.part?.sessionID
             if (sid) {
-              try { updateActiveTrace({ sessionId: String(sid) }) } catch {}
+              try {
+                updateActiveTrace({ sessionId: String(sid) })
+              } catch {}
             }
             const t = evt.type as string
 
@@ -77,7 +79,10 @@ try {
               }
               if (part.type === "tool") {
                 if (part.state.status === "pending" || part.state.status === "running") {
-                  const s = startObservation(`tool:${part.tool}`, { input: part.state.input, metadata: { callID: part.callID } })
+                  const s = startObservation(`tool:${part.tool}`, {
+                    input: part.state.input,
+                    metadata: { callID: part.callID },
+                  })
                   toolObs.set(part.callID, s)
                   return
                 }
@@ -107,7 +112,9 @@ try {
                 return
               }
               if (part.type === "file") {
-                const s = startObservation("file", { input: { mime: part.mime, filename: part.filename, url: part.url } })
+                const s = startObservation("file", {
+                  input: { mime: part.mime, filename: part.filename, url: part.url },
+                })
                 s.end()
                 return
               }
@@ -119,7 +126,10 @@ try {
             if (t === "message.updated" && p?.info) {
               const info = p.info as any
               if (info.role === "assistant") {
-                const s = startObservation("assistant", { type: "GENERATION", metadata: { providerID: info.providerID, modelID: info.modelID } })
+                const s = startObservation("assistant", {
+                  type: "GENERATION",
+                  metadata: { providerID: info.providerID, modelID: info.modelID },
+                })
                 s.update({ metadata: { tokens: info.tokens, cost: info.cost } })
                 s.end()
                 return

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1107,7 +1107,8 @@ export namespace SessionPrompt {
                 },
               ).toObject()
               break
-            case input.abort.aborted || (e instanceof Error && e.message?.includes("was provided without its required following item")):
+            case input.abort.aborted ||
+              (e instanceof Error && e.message?.includes("was provided without its required following item")):
               // Treat user-initiated interrupt and interrupted OpenAI streaming as a clean abort
               assistantMsg.error = new MessageV2.AbortedError(
                 { message: "Request was aborted" },


### PR DESCRIPTION
This PR re-branches smarty from fixes-clean and applies minimal brand overlay + Langfuse (env-gated).\n\nInvariants:\n- Engine code matches fixes-clean\n- Brand via UI.brand() + BRAND env; no dist tracked\n- Langfuse present but gated by env\n\nVerification:\n- Help shows smartypants; OPENCODE_FORCE_DEV=1 skips stale binaries\n- git ls-files | rg /dist/ → none\n- Diff scope limited to CLI/TUI texts, server OpenAPI title/desc, and brand helpers