### PR TITLE
fixes: splash cursor baseline + align branding to upstream + 'no Smarty' gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep opencode branding defaults in downstream/fixes during merges
+packages/smartypants/src/cli/ui.ts merge=ours
+packages/tui/internal/tui/tui.go merge=ours
+packages/tui/internal/components/status/status.go merge=ours

--- a/.github/workflows/branding-gate.yml
+++ b/.github/workflows/branding-gate.yml
@@ -1,0 +1,39 @@
+name: branding-gate
+
+on:
+  push:
+    branches: [downstream/fixes]
+  pull_request:
+    branches: [downstream/fixes]
+
+permissions:
+  contents: read
+
+jobs:
+  branding:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Check default brand and banned strings
+        run: |
+          set -euo pipefail
+          # Required opencode defaults
+          rg -n 'BRAND\s*=\s*process\.env\["BRAND"\]\s*\?\?\s*"opencode"' packages/smartypants/src/cli/ui.ts >/dev/null
+          rg -n 'brand\s*=\s*"opencode"' packages/tui/internal/tui/tui.go >/dev/null
+          rg -n 'brandName\s*=\s*"opencode"' packages/tui/internal/components/status/status.go >/dev/null
+
+          # Must not default to smarty
+          if rg -n '(?i)BRAND.*smarty' packages/smartypants/src/cli/ui.ts; then
+            echo "::error::ui.ts defaults BRAND to smarty"; exit 1; fi
+          if rg -n '(?i)brand\s*=\s*"smarty"' packages/tui/internal/tui/tui.go; then
+            echo "::error::tui.go defaults brand to smarty"; exit 1; fi
+          if rg -n '(?i)brandName\s*=\s*"smarty"' packages/tui/internal/components/status/status.go; then
+            echo "::error::status.go defaults brand to smarty"; exit 1; fi
+
+          # Catch ASCII banners that spell SMARTY
+          if rg -n '(?i)SMARTY' packages/tui/internal/tui/tui.go; then
+            echo "::error::tui.go contains SMARTY banner"; exit 1; fi

--- a/.github/workflows/branding-gate.yml
+++ b/.github/workflows/branding-gate.yml
@@ -21,19 +21,9 @@ jobs:
       - name: Check default brand and banned strings
         run: |
           set -euo pipefail
-          # Required opencode defaults
-          rg -n 'BRAND\s*=\s*process\.env\["BRAND"\]\s*\?\?\s*"opencode"' packages/smartypants/src/cli/ui.ts >/dev/null
-          rg -n 'brand\s*=\s*"opencode"' packages/tui/internal/tui/tui.go >/dev/null
-          rg -n 'brandName\s*=\s*"opencode"' packages/tui/internal/components/status/status.go >/dev/null
-
-          # Must not default to smarty
-          if rg -n '(?i)BRAND.*smarty' packages/smartypants/src/cli/ui.ts; then
-            echo "::error::ui.ts defaults BRAND to smarty"; exit 1; fi
-          if rg -n '(?i)brand\s*=\s*"smarty"' packages/tui/internal/tui/tui.go; then
-            echo "::error::tui.go defaults brand to smarty"; exit 1; fi
-          if rg -n '(?i)brandName\s*=\s*"smarty"' packages/tui/internal/components/status/status.go; then
-            echo "::error::status.go defaults brand to smarty"; exit 1; fi
-
-          # Catch ASCII banners that spell SMARTY
-          if rg -n '(?i)SMARTY' packages/tui/internal/tui/tui.go; then
-            echo "::error::tui.go contains SMARTY banner"; exit 1; fi
+          # Must not include Smarty branding in fixes
+          if rg -n '(?i)\bsmarty\b' packages/**/*.ts packages/**/*.go packages/**/*.md; then
+            echo "::error::Found 'smarty' branding strings in fixes"; exit 1; fi
+          # Allow the templating language "Smarty" in file-icons/types.ts
+          if rg -n '(?i)\bSmarty\b' packages/app/src/ui/file-icons/types.ts; then
+            echo "Found Smarty in file-icons/types.ts (allowed)"; fi

--- a/README.md
+++ b/README.md
@@ -109,17 +109,17 @@ The other confusingly named repo has no relation to this one. You can [read the 
 
 **Join our community** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
 
-## Smarty‑Pants Fork: Local Wrapper Commands
+## Local Wrapper Commands
 
 This repo configures two local wrapper commands that always run the latest code from our worktrees:
 
 - `opencode-fixes` → `.worktrees/opencode-fixes` (branch: `downstream/fixes`)
-- `smarty` → `.worktrees/opencode-smarty` (branch: `downstream/smarty`)
+
 
 They are installed as wrappers in `scripts/` and exposed on PATH via `~/.local/bin` symlinks:
 
 - `~/.local/bin/opencode-fixes` → `<repo>/scripts/opencode-fixes`
-- `~/.local/bin/smarty` → `<repo>/scripts/smarty`
+
 
 Both wrappers provide:
 - `--where`: print the worktree path, branch, and commit
@@ -130,14 +130,14 @@ Examples
 
 ```bash
 opencode-fixes --where     # verify worktree + branch
-smarty --where
+
 
 opencode-fixes --switch    # align to downstream/fixes (requires clean worktree)
-smarty --switch            # align to downstream/smarty
+
 
 # Non‑interactive single‑shot runs (model latency expected)
 opencode-fixes run "whats 2+2?"
-smarty run "whats 2+2?"
+
 ```
 
 Single source of truth + easy flips
@@ -146,7 +146,7 @@ Single source of truth + easy flips
   - Option A (one‑off): run the CLI directly from a worktree:
     ```bash
     bun --cwd .worktrees/opencode-fixes/packages/opencode ./src/index.ts …
-    bun --cwd .worktrees/opencode-smarty/packages/smartypants ./src/index.ts …
+    
     ```
   - Option B (short‑term): repoint the symlink, then restore:
     ```bash

--- a/external/opencode/README.md
+++ b/external/opencode/README.md
@@ -1,16 +1,16 @@
 
-## Smarty‑Pants: Local Wrapper Commands (Fork Usage)
+## Local Wrapper Commands (Fork Usage)
 
-In the Smarty‑Pants fork, we use two local wrapper commands that run the latest code from our worktrees in `smarty-dev`:
+In this fork, use a local wrapper command that runs the latest code from our worktrees in `smarty-dev`:
 
 - `opencode-fixes` → `<repo-root>/.worktrees/opencode-fixes` (branch: `downstream/fixes`)
-- `smarty` → `<repo-root>/.worktrees/opencode-smarty` (branch: `downstream/smarty`)
+
 
 Wrappers live in `smarty-dev/scripts/` and are exposed on PATH via `~/.local/bin` symlinks:
 
 ```bash
 ln -sf /Users/paulbettner/Projects/smarty-dev/scripts/opencode-fixes ~/.local/bin/opencode-fixes
-ln -sf /Users/paulbettner/Projects/smarty-dev/scripts/smarty ~/.local/bin/smarty
+
 ```
 
 Features:
@@ -21,9 +21,9 @@ Features:
 Usage:
 ```bash
 opencode-fixes --where
-smarty --where
+
 opencode-fixes --switch
-smarty --switch
+
 opencode-fixes run "whats 2+2?"   # "4" (LLM latency expected)
 ```
 
@@ -31,7 +31,7 @@ Temporarily flip to a different worktree while developing:
 - Run the CLI directly from a worktree (no PATH change):
   ```bash
   bun --cwd /Users/paulbettner/Projects/smarty-dev/.worktrees/opencode-fixes/packages/opencode ./src/index.ts …
-  bun --cwd /Users/paulbettner/Projects/smarty-dev/.worktrees/opencode-smarty/packages/smartypants ./src/index.ts …
+  
   ```
 - Or repoint the symlink temporarily (and restore afterward):
   ```bash

--- a/packages/smartypants/src/cli/cmd/attach.ts
+++ b/packages/smartypants/src/cli/cmd/attach.ts
@@ -9,7 +9,7 @@ import { $ } from "bun"
 
 export const AttachCommand = cmd({
   command: "attach <server>",
-  describe: `attach to a running ${UI.BRAND} server`,
+  describe: "attach to a running opencode server",
   builder: (yargs) =>
     yargs.positional("server", {
       type: "string",
@@ -49,7 +49,7 @@ export const AttachCommand = cmd({
         ...process.env,
         CGO_ENABLED: "0",
         OPENCODE_SERVER: args.server,
-        BRAND: UI.BRAND,
+
       },
     })
 

--- a/packages/smartypants/src/cli/cmd/attach.ts
+++ b/packages/smartypants/src/cli/cmd/attach.ts
@@ -49,7 +49,7 @@ export const AttachCommand = cmd({
         ...process.env,
         CGO_ENABLED: "0",
         OPENCODE_SERVER: args.server,
-        BRAND: process.env["BRAND"] ?? "smarty",
+        BRAND: UI.BRAND,
       },
     })
 

--- a/packages/smartypants/src/cli/cmd/attach.ts
+++ b/packages/smartypants/src/cli/cmd/attach.ts
@@ -3,7 +3,6 @@ import { cmd } from "./cmd"
 import path from "path"
 import fs from "fs/promises"
 import { Log } from "../../util/log"
-import { UI } from "../ui"
 
 import { $ } from "bun"
 

--- a/packages/smartypants/src/cli/cmd/auth.ts
+++ b/packages/smartypants/src/cli/cmd/auth.ts
@@ -70,7 +70,7 @@ export const AuthLoginCommand = cmd({
   describe: "log in to a provider",
   builder: (yargs) =>
     yargs.positional("url", {
-      describe: `${UI.BRAND} auth provider`,
+        describe: "opencode auth provider",
       type: "string",
     }),
   async handler(args) {

--- a/packages/smartypants/src/cli/cmd/run.ts
+++ b/packages/smartypants/src/cli/cmd/run.ts
@@ -28,7 +28,7 @@ const TOOL: Record<string, [string, string]> = {
 
 export const RunCommand = cmd({
   command: "run [message..]",
-  describe: `run ${UI.BRAND} with a message`,
+  describe: "run opencode with a message",
   builder: (yargs: Argv) => {
     return yargs
       .positional("message", {

--- a/packages/smartypants/src/cli/cmd/serve.ts
+++ b/packages/smartypants/src/cli/cmd/serve.ts
@@ -1,6 +1,5 @@
 import { Server } from "../../server/server"
 import { cmd } from "./cmd"
-import { UI } from "../ui"
 
 export const ServeCommand = cmd({
   command: "serve",

--- a/packages/smartypants/src/cli/cmd/serve.ts
+++ b/packages/smartypants/src/cli/cmd/serve.ts
@@ -18,7 +18,7 @@ export const ServeCommand = cmd({
         describe: "hostname to listen on",
         default: "127.0.0.1",
       }),
-  describe: `starts a headless ${UI.BRAND} server`,
+  describe: "starts a headless opencode server",
   handler: async (args) => {
     const hostname = args.hostname
     const port = args.port

--- a/packages/smartypants/src/cli/cmd/tui.ts
+++ b/packages/smartypants/src/cli/cmd/tui.ts
@@ -27,13 +27,13 @@ if (typeof OPENCODE_TUI_PATH !== "undefined") {
 }
 
 export const TuiCommand = cmd({
-  command: "tui [project]",
-  describe: `start ${UI.BRAND} tui`,
+  command: "$0 [project]",
+  describe: "start opencode tui",
   builder: (yargs) =>
     yargs
       .positional("project", {
         type: "string",
-        describe: `path to start ${UI.BRAND} in`,
+        describe: "path to start opencode in",
       })
       .option("model", {
         type: "string",
@@ -156,7 +156,7 @@ export const TuiCommand = cmd({
             ...process.env,
             CGO_ENABLED: "0",
             OPENCODE_SERVER: server.url.toString(),
-            BRAND: UI.BRAND,
+
           },
           onExit: () => {
             server.stop()

--- a/packages/smartypants/src/cli/cmd/tui.ts
+++ b/packages/smartypants/src/cli/cmd/tui.ts
@@ -113,10 +113,14 @@ export const TuiCommand = cmd({
         const tui = Bun.embeddedFiles.find((item) => (item as File).name.includes("tui")) as File
         if (tui && !Installation.isDev()) {
           let binaryName = tui.name
+          // Ensure we do not treat the embedded name as an absolute path
+          binaryName = path.basename(binaryName)
           if (process.platform === "win32" && !binaryName.endsWith(".exe")) {
             binaryName += ".exe"
           }
-          const binary = path.join(Global.Path.cache, "tui", binaryName)
+          const outDir = path.join(Global.Path.cache, "tui")
+          await fs.mkdir(outDir, { recursive: true }).catch(() => {})
+          const binary = path.join(outDir, binaryName)
           const file = Bun.file(binary)
           if (!(await file.exists())) {
             await Bun.write(file, tui, { mode: 0o755 })
@@ -126,9 +130,20 @@ export const TuiCommand = cmd({
         }
         if (!tui || Installation.isDev()) {
           const dir = Bun.fileURLToPath(new URL("../../../../tui/cmd/smartypants", import.meta.url))
-          let binaryName = `./dist/tui${process.platform === "win32" ? ".exe" : ""}`
-          await $`go build -o ${binaryName} ./main.go`.cwd(dir)
-          cmd = [path.join(dir, binaryName)]
+          const prebuiltDir = Bun.fileURLToPath(new URL("../../../../tui", import.meta.url))
+          const exe = process.platform === "win32" ? ".exe" : ""
+          const prebuilt = path.join(prebuiltDir, `smartypants${exe}`)
+          const pbFile = Bun.file(prebuilt)
+          if (await pbFile.exists()) {
+            try { if (process.platform !== "win32") await fs.chmod(prebuilt, 0o755) } catch {}
+            cmd = [prebuilt]
+          } else {
+            let binaryName = `./dist/tui${exe}`
+            await fs.mkdir(path.join(dir, "dist"), { recursive: true })
+            const envPath = ["/opt/homebrew/bin", "/usr/local/go/bin", process.env["PATH"]].filter(Boolean).join(":")
+            await $`go build -o ${binaryName} ./main.go`.cwd(dir).env({ ...process.env, PATH: envPath })
+            cmd = [path.join(dir, binaryName)]
+          }
         }
         Log.Default.info("tui", {
           cmd,

--- a/packages/smartypants/src/cli/cmd/tui.ts
+++ b/packages/smartypants/src/cli/cmd/tui.ts
@@ -27,7 +27,7 @@ if (typeof OPENCODE_TUI_PATH !== "undefined") {
 }
 
 export const TuiCommand = cmd({
-  command: "$0 [project]",
+  command: "tui [project]",
   describe: `start ${UI.BRAND} tui`,
   builder: (yargs) =>
     yargs

--- a/packages/smartypants/src/cli/cmd/tui.ts
+++ b/packages/smartypants/src/cli/cmd/tui.ts
@@ -130,20 +130,12 @@ export const TuiCommand = cmd({
         }
         if (!tui || Installation.isDev()) {
           const dir = Bun.fileURLToPath(new URL("../../../../tui/cmd/smartypants", import.meta.url))
-          const prebuiltDir = Bun.fileURLToPath(new URL("../../../../tui", import.meta.url))
           const exe = process.platform === "win32" ? ".exe" : ""
-          const prebuilt = path.join(prebuiltDir, `smartypants${exe}`)
-          const pbFile = Bun.file(prebuilt)
-          if (await pbFile.exists()) {
-            try { if (process.platform !== "win32") await fs.chmod(prebuilt, 0o755) } catch {}
-            cmd = [prebuilt]
-          } else {
-            let binaryName = `./dist/tui${exe}`
-            await fs.mkdir(path.join(dir, "dist"), { recursive: true })
-            const envPath = ["/opt/homebrew/bin", "/usr/local/go/bin", process.env["PATH"]].filter(Boolean).join(":")
-            await $`go build -o ${binaryName} ./main.go`.cwd(dir).env({ ...process.env, PATH: envPath })
-            cmd = [path.join(dir, binaryName)]
-          }
+          let binaryName = `./dist/tui${exe}`
+          await fs.mkdir(path.join(dir, "dist"), { recursive: true })
+          const envPath = ["/opt/homebrew/bin", "/usr/local/go/bin", process.env["PATH"]].filter(Boolean).join(":")
+          await $`go build -o ${binaryName} ./main.go`.cwd(dir).env({ ...process.env, PATH: envPath })
+          cmd = [path.join(dir, binaryName)]
         }
         Log.Default.info("tui", {
           cmd,

--- a/packages/smartypants/src/cli/cmd/upgrade.ts
+++ b/packages/smartypants/src/cli/cmd/upgrade.ts
@@ -5,7 +5,7 @@ import { Installation } from "../../installation"
 
 export const UpgradeCommand = {
   command: "upgrade [target]",
-  describe: `upgrade ${UI.BRAND} to the latest or a specific version`,
+  describe: "upgrade opencode to the latest or a specific version",
   builder: (yargs: Argv) => {
     return yargs
       .positional("target", {
@@ -27,7 +27,7 @@ export const UpgradeCommand = {
     const detectedMethod = await Installation.method()
     const method = (args.method as Installation.Method) ?? detectedMethod
     if (method === "unknown") {
-      prompts.log.error(`${UI.BRAND} is installed to ${process.execPath} and seems to be managed by a package manager`)
+      prompts.log.error(`opencode is installed to ${process.execPath} and seems to be managed by a package manager`)
       prompts.outro("Done")
       return
     }
@@ -35,7 +35,7 @@ export const UpgradeCommand = {
     const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest()
 
     if (Installation.VERSION === target) {
-      prompts.log.warn(`${UI.BRAND} upgrade skipped: ${target} is already installed`)
+      prompts.log.warn(`opencode upgrade skipped: ${target} is already installed`)
       prompts.outro("Done")
       return
     }

--- a/packages/smartypants/src/cli/error.ts
+++ b/packages/smartypants/src/cli/error.ts
@@ -4,7 +4,7 @@ import { UI } from "./ui"
 
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
-    return `MCP server "${input.data.name}" failed. Note, ${UI.BRAND} does not support MCP authentication yet.`
+    return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
   if (Config.JsonError.isInstance(input)) {
     return (
       `Config file at ${input.data.path} is not valid JSON(C)` + (input.data.message ? `: ${input.data.message}` : "")

--- a/packages/smartypants/src/cli/ui.ts
+++ b/packages/smartypants/src/cli/ui.ts
@@ -92,11 +92,10 @@ export namespace UI {
   }
 
   export function logo(pad?: string) {
-    const useTrueColor = supportsTrueColor()
     const result: string[] = []
     for (const row of LOGO) {
       if (pad) result.push(pad)
-      result.push(renderRainbowLine(row, useTrueColor))
+      result.push(row)
       result.push(EOL)
     }
     return result.join("").trimEnd()

--- a/packages/smartypants/src/cli/ui.ts
+++ b/packages/smartypants/src/cli/ui.ts
@@ -3,13 +3,13 @@ import { EOL } from "os"
 import { NamedError } from "../util/error"
 
 export namespace UI {
-  const LOGO = [
-    "OPENCODE",
+  const LOGO: [string, string][] = [
+    ["█▀▀█ █▀▀█ █▀▀ █▀▀▄ ", "█▀▀ █▀▀█ █▀▀▄ █▀▀"],
+    ["█░░█ █░░█ █▀▀ █░░█ ", "█░░ █░░█ █░░█ █▀▀"],
+    ["▀▀▀▀ █▀▀▀ ▀▀▀ ▀  ▀ ", "▀▀▀ ▀▀▀▀ ▀▀▀  ▀▀▀"],
   ]
 
   export const CancelledError = NamedError.create("UICancelledError", z.void())
-
-  export const BRAND = process.env["BRAND"] ?? "opencode"
 
   export const Style = {
     TEXT_HIGHLIGHT: "\x1b[96m",
@@ -45,9 +45,17 @@ export namespace UI {
     blank = true
   }
 
-  function supportsTrueColor(): boolean {
-    const c = (process.env["COLORTERM"] || "").toLowerCase()
-    return c.includes("truecolor") || c.includes("24bit")
+  export function logo(pad?: string) {
+    const result: string[] = []
+    for (const row of LOGO) {
+      if (pad) result.push(pad)
+      result.push(Bun.color("gray", "ansi"))
+      result.push(row[0])
+      result.push("\x1b[0m")
+      result.push(row[1])
+      result.push(EOL)
+    }
+    return result.join("").trimEnd()
   }
 
   function rgbEsc(r: number, g: number, b: number): string {

--- a/packages/smartypants/src/cli/ui.ts
+++ b/packages/smartypants/src/cli/ui.ts
@@ -49,7 +49,7 @@ export namespace UI {
     const result: string[] = []
     for (const row of LOGO) {
       if (pad) result.push(pad)
-      result.push(Bun.color("gray", "ansi"))
+      result.push(Bun.color("gray", "ansi") ?? "")
       result.push(row[0])
       result.push("\x1b[0m")
       result.push(row[1])
@@ -58,56 +58,7 @@ export namespace UI {
     return result.join("").trimEnd()
   }
 
-  function rgbEsc(r: number, g: number, b: number): string {
-    return `\x1b[38;2;${r};${g};${b}m`
-  }
 
-  function rainbowAnsi(code: number): string {
-    return `\x1b[${code}m`
-  }
-
-  function renderRainbowLine(line: string, useTrueColor: boolean): string {
-    // 7-color rainbow (ROYGCBV)
-    const colorsRGB = [
-      [255, 0, 0],
-      [255, 127, 0],
-      [255, 255, 0],
-      [0, 255, 0],
-      [0, 255, 255],
-      [0, 0, 255],
-      [139, 0, 255],
-    ]
-    const colorsANSI = [91, 93, 92, 96, 94, 95, 91]
-
-    const runes = Array.from(line)
-    const width = runes.length
-    let out = ""
-    for (let x = 0; x < width; x++) {
-      const ch = runes[x]
-      if (ch === " ") {
-        out += " "
-        continue
-      }
-      const idx = width > 1 ? Math.floor((x / (width - 1)) * (colorsRGB.length - 1)) : 0
-      if (useTrueColor) {
-        const [r, g, b] = colorsRGB[idx]
-        out += rgbEsc(r, g, b) + ch
-      } else {
-        out += rainbowAnsi(colorsANSI[idx]) + ch
-      }
-    }
-    return out + "\x1b[0m"
-  }
-
-  export function logo(pad?: string) {
-    const result: string[] = []
-    for (const row of LOGO) {
-      if (pad) result.push(pad)
-      result.push(row)
-      result.push(EOL)
-    }
-    return result.join("").trimEnd()
-  }
 
   export async function input(prompt: string): Promise<string> {
     const readline = require("readline")

--- a/packages/smartypants/src/cli/ui.ts
+++ b/packages/smartypants/src/cli/ui.ts
@@ -4,20 +4,12 @@ import { NamedError } from "../util/error"
 
 export namespace UI {
   const LOGO = [
-    "                                                   .               ",
-    "                                                 .o8               ",
-    "  .oooo.o ooo. .oo.  .oo.    .oooo.   oooo d8b .o888oo oooo    ooo ",
-    ' d88(  "8 `888P"Y88bP"Y88b  `P  )88b  `888""8P   888    `88.  .8\'  ',
-    ' `"Y88b.   888   888   888   .oP"888   888       888     `88..8\'   ',
-    " o.  )88b  888   888   888  d8(  888   888       888 .    `888'    ",
-    ' 8""888P\' o888o o888o o888o `Y888""8o d888b      "888"     .8\'     ',
-    "                                                       .o..P'      ",
-    "                                                       `Y8P'       ",
+    "OPENCODE",
   ]
 
   export const CancelledError = NamedError.create("UICancelledError", z.void())
 
-  export const BRAND = process.env["BRAND"] ?? "smarty"
+  export const BRAND = process.env["BRAND"] ?? "opencode"
 
   export const Style = {
     TEXT_HIGHLIGHT: "\x1b[96m",

--- a/packages/smartypants/src/index.ts
+++ b/packages/smartypants/src/index.ts
@@ -180,7 +180,7 @@ process.on("uncaughtException", (e) => {
 })
 
 const cli = yargs(hideBin(process.argv))
-  .scriptName(UI.BRAND)
+  .scriptName("opencode")
   .help("help", "show help")
   .version("version", "show version number", Installation.VERSION)
   .alias("version", "v")

--- a/packages/smartypants/src/provider/models.ts
+++ b/packages/smartypants/src/provider/models.ts
@@ -62,6 +62,10 @@ export namespace ModelsDev {
   }
 
   export async function refresh() {
+    // Allow disabling models.dev refresh in non-interactive/CI runs to avoid network stalls
+    if ((process.env["OPENCODE_DISABLE_MODELS_REFRESH"] ?? "").match(/^(1|true)$/i)) {
+      return
+    }
     const file = Bun.file(filepath)
     log.info("refreshing", {
       file,

--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -92,7 +92,7 @@ func (m *statusComponent) logo() string {
 
 	brandName := os.Getenv("BRAND")
 	if brandName == "" {
-		brandName = "smarty"
+		brandName = "opencode"
 	}
 	brand := emphasis(strings.ToLower(brandName))
 	version := base(" " + m.app.Version)

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -1058,7 +1058,16 @@ func (a Model) home() (string, int, int) {
 
 	editorView := a.editor.View()
 	editorWidth := lipgloss.Width(editorView)
-undefined		effectiveWidth,
+	editorView = lipgloss.PlaceHorizontal(
+		effectiveWidth,
+		lipgloss.Center,
+		editorView,
+		styles.WhitespaceStyle(t.Background()),
+	)
+	// Append editor view for single-line baseline
+	lines = append(lines, editorView)
+	mainLayout := lipgloss.Place(
+		effectiveWidth,
 		a.height,
 		lipgloss.Center,
 		lipgloss.Center,
@@ -1068,12 +1077,10 @@ undefined		effectiveWidth,
 
 	editorX := max(0, (effectiveWidth-editorWidth)/2)
 	editorY := (a.height / 2) + (mainHeight / 2) - 3
-	editorYDelta := 3
 
 	// Compute editor lines and set cursor offset
 	editorLines := a.editor.Lines()
 	if editorLines > 1 {
-		editorYDelta = 2
 		content := a.editor.Content()
 		editorHeight := lipgloss.Height(content)
 		if editorY+editorHeight > a.height {
@@ -1119,8 +1126,6 @@ func (a Model) chat() (string, int, int) {
 		editorView,
 		styles.WhitespaceStyle(t.Background()),
 	)
-	// Append editor view to lines for single-line case
-	lines = append(lines, editorView)
 
 	mainLayout := messagesView + "\n" + editorView
 	editorX := max(0, (effectiveWidth-editorWidth)/2)

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -461,7 +461,7 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case opencode.EventListResponseEventInstallationUpdated:
 		brand := os.Getenv("BRAND")
 		if brand == "" {
-			brand = "smarty"
+			brand = "opencode"
 		}
 		return a, toast.NewSuccessToast(
 			brand+" updated to "+msg.Properties.Version+", restart to apply.",
@@ -992,15 +992,7 @@ func (a Model) home() (string, int, int) {
 
 	open := ""
 
-	code := "                                                   .               \n" +
-		"                                                 .o8               \n" +
-		"  .oooo.o ooo. .oo.  .oo.    .oooo.   oooo d8b .o888oo oooo    ooo \n" +
-		" d88(  \"8 `888P\"Y88bP\"Y88b  `P  )88b  `888\"\"8P   888    `88.  .8'  \n" +
-		" `\"Y88b.   888   888   888   .oP\"888   888       888     `88..8'   \n" +
-		" o.  )88b  888   888   888  d8(  888   888       888 .    `888'    \n" +
-		" 8\"\"888P' o888o o888o o888o `Y888\"\"8o d888b      \"888\"     .8'     \n" +
-		"                                                       .o..P'      \n" +
-		"                                                       `Y8P'       "
+	code := "OPENCODE"
 
 	// Render rainbow gradient across the ASCII logo
 	renderRainbow := func(s string) string {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -1058,15 +1058,7 @@ func (a Model) home() (string, int, int) {
 
 	editorView := a.editor.View()
 	editorWidth := lipgloss.Width(editorView)
-	editorView = lipgloss.PlaceHorizontal(
-		effectiveWidth,
-		lipgloss.Center,
-		editorView,
-		styles.WhitespaceStyle(t.Background()),
-	)
-
-	mainLayout := lipgloss.Place(
-		effectiveWidth,
+undefined		effectiveWidth,
 		a.height,
 		lipgloss.Center,
 		lipgloss.Center,
@@ -1082,19 +1074,19 @@ func (a Model) home() (string, int, int) {
 	editorLines := a.editor.Lines()
 	if editorLines > 1 {
 		editorYDelta = 2
+		content := a.editor.Content()
+		editorHeight := lipgloss.Height(content)
+		if editorY+editorHeight > a.height {
+			difference := (editorY + editorHeight) - a.height
+			editorY -= difference
+		}
+		mainLayout = layout.PlaceOverlay(
+			editorX,
+			editorY,
+			content,
+			mainLayout,
+		)
 	}
-	// Overlay the editor view (with cursor) so caret aligns
-	editorHeight := lipgloss.Height(editorView)
-	if editorY+editorHeight > a.height {
-		difference := (editorY + editorHeight) - a.height
-		editorY -= difference
-	}
-	mainLayout = layout.PlaceOverlay(
-		editorX,
-		editorY,
-		editorView,
-		mainLayout,
-	)
 
 	if a.showCompletionDialog {
 		a.completions.SetWidth(editorWidth)
@@ -1109,7 +1101,7 @@ func (a Model) home() (string, int, int) {
 		)
 	}
 
-	return mainLayout, editorX + 5, editorY + editorYDelta
+	return mainLayout, editorX + 5, editorY + 3
 }
 
 func (a Model) chat() (string, int, int) {
@@ -1127,6 +1119,8 @@ func (a Model) chat() (string, int, int) {
 		editorView,
 		styles.WhitespaceStyle(t.Background()),
 	)
+	// Append editor view to lines for single-line case
+	lines = append(lines, editorView)
 
 	mainLayout := messagesView + "\n" + editorView
 	editorX := max(0, (effectiveWidth-editorWidth)/2)

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -16,7 +16,6 @@ import (
 	"github.com/charmbracelet/bubbles/v2/key"
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss/v2"
-	"github.com/charmbracelet/lipgloss/v2/compat"
 
 	"github.com/sst/opencode-sdk-go"
 	"github.com/sst/opencode/internal/api"
@@ -994,37 +993,13 @@ func (a Model) home() (string, int, int) {
 
 	code := "OPENCODE"
 
-	// Render rainbow gradient across the ASCII logo
-	renderRainbow := func(s string) string {
-		colors := []string{"#ff0000", "#ff7f00", "#ffff00", "#00ff00", "#00ffff", "#0000ff", "#8b00ff"}
-		lines := strings.Split(s, "\n")
-		var out []string
-		for _, line := range lines {
-			runes := []rune(line)
-			w := len(runes)
-			if w == 0 {
-				out = append(out, "")
-				continue
-			}
-			var b strings.Builder
-			for x, r := range runes {
-				if r == ' ' {
-					b.WriteRune(' ')
-					continue
-				}
-				idx := int(float64(x) / float64(max(w-1, 1)) * float64(len(colors)-1))
-				st := styles.NewStyle().Foreground(compat.AdaptiveColor{Dark: lipgloss.Color(colors[idx]), Light: lipgloss.Color(colors[idx])}).Background(t.Background())
-				b.WriteString(st.Render(string(r)))
-			}
-			out = append(out, b.String())
-		}
-		return strings.Join(out, "\n")
-	}
+	// Render logo in primary color (no gradient in fixes)
+	styleLogo := styles.NewStyle().Foreground(t.Primary()).Background(t.Background())
 
 	logo := lipgloss.JoinHorizontal(
 		lipgloss.Top,
 		muted(open),
-		renderRainbow(code),
+		styleLogo.Render(code),
 	)
 	// cwd := app.Info.Path.Cwd
 	// config := app.Info.Path.Config

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -989,17 +989,24 @@ func (a Model) home() (string, int, int) {
 	baseStyle := styles.NewStyle().Foreground(t.Text()).Background(t.Background())
 	muted := styles.NewStyle().Foreground(t.TextMuted()).Background(t.Background()).Render
 
-	open := ""
+	open := `
+                    
+█▀▀█ █▀▀█ █▀▀█ █▀▀▄ 
+█░░█ █░░█ █▀▀▀ █░░█ 
+▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ `
 
-	code := "OPENCODE"
+	code := `
+             ▄
+█▀▀▀ █▀▀█ █▀▀█ █▀▀█
+█░░░ █░░█ █░░█ █▀▀▀
+▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀`
 
-	// Render logo in primary color (no gradient in fixes)
-	styleLogo := styles.NewStyle().Foreground(t.Primary()).Background(t.Background())
+	base := baseStyle.Render
 
 	logo := lipgloss.JoinHorizontal(
 		lipgloss.Top,
 		muted(open),
-		styleLogo.Render(code),
+		base(code),
 	)
 	// cwd := app.Info.Path.Cwd
 	// config := app.Info.Path.Config


### PR DESCRIPTION
## Summary
- Align CLI/TUI branding with upstream opencode (remove UI.BRAND/env use in fixes)
- Add CI gate to block "Smarty" branding in fixes (allow templating language entry)
- Fix TUI home splash cursor baseline (single-line editor offset; overlay only multi-line)
- Dev wrapper ensures fresh Go TUI build; no stale prebuilt
- Typecheck cleanups: remove unused imports, duplicate logo, old rainbow helpers

## Why
- downstream/fixes must contain only performance/bug fixes; no Smarty branding
- Prevent branding regressions; fix persistent off-by-one cursor on splash