### PR TITLE
feat(storage): unify sessions by superproject; migrate legacy buckets

### DIFF
--- a/packages/smartypants/src/cli/cmd/tui.ts
+++ b/packages/smartypants/src/cli/cmd/tui.ts
@@ -83,13 +83,17 @@ export const TuiCommand = cmd({
         const sessionID = await (async () => {
           if (args.continue) {
             const it = Session.list()
+            let latest: { id: string; updated: number } | undefined
             try {
               for await (const s of it) {
                 if (s.parentID === undefined) {
-                  return s.id
+                  const updated = s.time?.updated ?? 0
+                  if (!latest || updated > latest.updated) {
+                    latest = { id: s.id, updated }
+                  }
                 }
               }
-              return
+              return latest?.id
             } finally {
               await it.return()
             }

--- a/packages/smartypants/src/project/project.ts
+++ b/packages/smartypants/src/project/project.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { $ } from "bun"
 import { Storage } from "../storage/storage"
 import { Log } from "../util/log"
+import { createHash } from "crypto"
 
 export namespace Project {
   const log = Log.create({ service: "project" })
@@ -27,56 +28,54 @@ export namespace Project {
     const matches = Filesystem.up({ targets: [".git"], start: directory })
     const git = await matches.next().then((x) => x.value)
     await matches.return()
+
+    // No git repo: use global bucket
     if (!git) {
       const project: Info = {
         id: "global",
         worktree: "/",
-        time: {
-          created: Date.now(),
-        },
+        time: { created: Date.now() },
       }
       await Storage.write<Info>(["project", "global"], project)
       return project
     }
-    let worktree = path.dirname(git)
-    const [id] = await $`git rev-list --max-parents=0 --all`
+
+    // Resolve canonical toplevel worktree path
+    let worktree = await $`git rev-parse --path-format=absolute --show-toplevel`
       .quiet()
       .nothrow()
-      .cwd(worktree)
+      .cwd(path.dirname(git))
       .text()
-      .then((x) =>
-        x
-          .split("\n")
-          .filter(Boolean)
-          .map((x) => x.trim())
-          .toSorted(),
-      )
-    if (!id) {
-      const project: Info = {
-        id: "global",
-        worktree: "/",
-        time: {
-          created: Date.now(),
-        },
-      }
-      await Storage.write<Info>(["project", "global"], project)
-      return project
-    }
-    worktree = await $`git rev-parse --path-format=absolute --show-toplevel`
+      .then((x) => x.trim())
+
+    // Prefer superproject working tree if this is a submodule
+    const superproject = await $`git rev-parse --show-superproject-working-tree`
       .quiet()
       .nothrow()
       .cwd(worktree)
       .text()
       .then((x) => x.trim())
-    const project: Info = {
-      id,
-      worktree,
-      vcs: "git",
-      time: {
-        created: Date.now(),
-      },
+      .catch(() => "")
+    if (superproject) {
+      worktree = superproject
     }
-    await Storage.write<Info>(["project", id], project)
+
+    // Compute stable project id from the anchor worktree path
+    const stableID = createHash("sha1").update(worktree).digest("hex")
+
+    // Ensure a project record exists for the stable id
+    let project: Info
+    try {
+      project = await Storage.read<Info>(["project", stableID])
+    } catch {
+      project = {
+        id: stableID,
+        worktree,
+        vcs: "git",
+        time: { created: Date.now() },
+      }
+      await Storage.write<Info>(["project", stableID], project)
+    }
     return project
   }
 

--- a/packages/smartypants/src/storage/storage.ts
+++ b/packages/smartypants/src/storage/storage.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import { Global } from "../global"
 import { lazy } from "../util/lazy"
 import { Lock } from "../util/lock"
+import { createHash } from "crypto"
 import { $ } from "bun"
 
 export namespace Storage {
@@ -12,6 +13,7 @@ export namespace Storage {
   type Migration = (dir: string) => Promise<void>
 
   const MIGRATIONS: Migration[] = [
+    // Legacy project layout -> hashed project id mapping
     async (dir) => {
       const project = path.resolve(dir, "../project")
       for await (const projectDir of new Bun.Glob("*").scan({
@@ -34,25 +36,15 @@ export namespace Storage {
           }
           if (!worktree) continue
           if (!(await fs.exists(worktree))) continue
-          const [id] = await $`git rev-list --max-parents=0 --all`
-            .quiet()
-            .nothrow()
-            .cwd(worktree)
-            .text()
-            .then((x) =>
-              x
-                .split("\n")
-                .filter(Boolean)
-                .map((x) => x.trim())
-                .toSorted(),
-            )
-          if (!id) continue
-          projectID = id
+
+          // Use stable hash of worktree path as new project id
+          const hashed = createHash("sha1").update(worktree).digest("hex")
+          projectID = hashed
 
           await Bun.write(
             path.join(dir, "project", projectID + ".json"),
             JSON.stringify({
-              id,
+              id: projectID,
               vcs: "git",
               worktree,
               time: {
@@ -107,6 +99,157 @@ export namespace Storage {
         }
       }
     },
+    // Consolidate sessions from any existing project IDs pointing to the same worktree into the hashed id
+    async (dir) => {
+      try {
+        const projectsDir = path.join(dir, "project")
+        // Build map: worktree -> set of projectIDs
+        const map = new Map<string, Set<string>>()
+        for await (const p of new Bun.Glob("*.json").scan({ cwd: projectsDir, absolute: true })) {
+          try {
+            const j = await Bun.file(p).json()
+            if (!j?.worktree || !j?.id) continue
+            const set = map.get(j.worktree) ?? new Set<string>()
+            set.add(j.id)
+            map.set(j.worktree, set)
+          } catch {}
+        }
+        for (const [worktree, ids] of map) {
+          const stable = createHash("sha1").update(worktree).digest("hex")
+          // Ensure stable project record exists
+          const stablePath = path.join(projectsDir, stable + ".json")
+          try {
+            await fs.access(stablePath)
+          } catch {
+            await Bun.write(
+              stablePath,
+              JSON.stringify({ id: stable, vcs: "git", worktree, time: { created: Date.now() } }),
+            )
+          }
+          // Merge sessions from all ids into stable
+          for (const id of ids) {
+            if (id === stable) continue
+            const srcDir = path.join(dir, "session", id)
+            const dstDir = path.join(dir, "session", stable)
+            try {
+              await fs.mkdir(dstDir, { recursive: true })
+            } catch {}
+            for await (const f of new Bun.Glob("*.json").scan({ cwd: srcDir, absolute: true })) {
+              const dest = path.join(dstDir, path.basename(f))
+              try {
+                await fs.access(dest)
+              } catch {
+                try {
+                  await fs.copyFile(f, dest)
+                } catch {}
+              }
+            }
+          }
+        }
+      } catch (e) {
+        log.error("failed consolidation migration", { error: e })
+      }
+    },
+    // Fallback: if we have sessions under session/<legacyID> but no project mapping, infer worktree from session info
+    async (dir) => {
+      try {
+        const sessionsRoot = path.join(dir, "session")
+        for await (const proj of new Bun.Glob("*").scan({ cwd: sessionsRoot, onlyFiles: false })) {
+          const legacyID = proj
+          if (!legacyID || legacyID === "global") continue
+          const srcDir = path.join(sessionsRoot, legacyID)
+          let inferredWorktree = ""
+          // Peek a session to infer worktree via git (prefer superproject)
+          for await (const sf of new Bun.Glob("*.json").scan({ cwd: srcDir, absolute: true })) {
+            try {
+              const session = await Bun.file(sf).json()
+              const directory = session?.directory as string | undefined
+              if (!directory) continue
+              const supertree = await $`git rev-parse --show-superproject-working-tree`.quiet().nothrow().cwd(directory).text().then((x) => x.trim()).catch(() => "")
+              if (supertree) {
+                inferredWorktree = supertree
+                break
+              }
+              const wt = await $`git rev-parse --path-format=absolute --show-toplevel`.quiet().nothrow().cwd(directory).text().then((x) => x.trim()).catch(() => "")
+              if (wt) {
+                inferredWorktree = wt
+                break
+              }
+            } catch {}
+          }
+          if (!inferredWorktree) continue
+          const stable = createHash("sha1").update(inferredWorktree).digest("hex")
+          const projectsDir = path.join(dir, "project")
+          // Ensure stable project record exists
+          try {
+            await fs.access(path.join(projectsDir, stable + ".json"))
+          } catch {
+            await fs.mkdir(projectsDir, { recursive: true }).catch(() => {})
+            await Bun.write(
+              path.join(projectsDir, stable + ".json"),
+              JSON.stringify({ id: stable, vcs: "git", worktree: inferredWorktree, time: { created: Date.now() } }),
+            )
+          }
+          const dstDir = path.join(sessionsRoot, stable)
+          await fs.mkdir(dstDir, { recursive: true }).catch(() => {})
+          for await (const f of new Bun.Glob("*.json").scan({ cwd: srcDir, absolute: true })) {
+            const dest = path.join(dstDir, path.basename(f))
+            try {
+              await fs.access(dest)
+            } catch {
+              try {
+                await fs.copyFile(f, dest)
+              } catch {}
+            }
+          }
+        }
+      } catch (e) {
+        log.error("failed fallback session migration", { error: e })
+      }
+    },
+    // Consolidate submodule project IDs into the superproject project ID
+    async (dir) => {
+      try {
+        const projectsDir = path.join(dir, "project")
+        for await (const p of new Bun.Glob("*.json").scan({ cwd: projectsDir, absolute: true })) {
+          try {
+            const j = await Bun.file(p).json()
+            const worktree = j?.worktree as string | undefined
+            const id = j?.id as string | undefined
+            if (!worktree || !id) continue
+            const supertree = await $`git rev-parse --show-superproject-working-tree`.quiet().nothrow().cwd(worktree).text().then((x) => x.trim()).catch(() => "")
+            if (!supertree) continue
+            const superID = createHash("sha1").update(supertree).digest("hex")
+            // Ensure superproject record exists
+            const superPath = path.join(projectsDir, superID + ".json")
+            try {
+              await fs.access(superPath)
+            } catch {
+              await Bun.write(
+                superPath,
+                JSON.stringify({ id: superID, vcs: "git", worktree: supertree, time: { created: Date.now() } }),
+              )
+            }
+            // Copy sessions from submodule project ID to superproject project ID (id -> superID)
+            const srcDir = path.join(dir, "session", id)
+            const dstDir = path.join(dir, "session", superID)
+            await fs.mkdir(dstDir, { recursive: true }).catch(() => {})
+            for await (const f of new Bun.Glob("*.json").scan({ cwd: srcDir, absolute: true })) {
+              const dest = path.join(dstDir, path.basename(f))
+              try {
+                await fs.access(dest)
+              } catch {
+                try {
+                  await fs.copyFile(f, dest)
+                } catch {}
+              }
+            }
+          } catch {}
+        }
+      } catch (e) {
+        log.error("failed superproject consolidation migration", { error: e })
+      }
+    },
   ]
 
   const state = lazy(async () => {
@@ -115,6 +258,7 @@ export namespace Storage {
       .json()
       .then((x) => parseInt(x))
       .catch(() => 0)
+    log.info("storage dir", { dir, migrationStart: migration })
     for (let index = migration; index < MIGRATIONS.length; index++) {
       log.info("running migration", { index })
       const migration = MIGRATIONS[index]
@@ -123,6 +267,14 @@ export namespace Storage {
       })
       await Bun.write(path.join(dir, "migration"), (index + 1).toString())
     }
+    // Debug: counts of project+session buckets discovered
+    try {
+      let projectCount = 0
+      for await (const _ of new Bun.Glob("*.json").scan({ cwd: path.join(dir, "project") })) projectCount++
+      let sessionBuckets = 0
+      for await (const _ of new Bun.Glob("*").scan({ cwd: path.join(dir, "session"), onlyFiles: false })) sessionBuckets++
+      log.info("storage summary", { projectCount, sessionBuckets })
+    } catch {}
     return {
       dir,
     }

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -985,10 +985,10 @@ func (a Model) Cleanup() {
 }
 
 func (a Model) home() (string, int, int) {
-	t := theme.CurrentTheme()
+	b := theme.CurrentTheme()
 	effectiveWidth := a.width - 4
-	baseStyle := styles.NewStyle().Foreground(t.Text()).Background(t.Background())
-	muted := styles.NewStyle().Foreground(t.TextMuted()).Background(t.Background()).Render
+	baseStyle := styles.NewStyle().Foreground(b.Text()).Background(b.Background())
+	muted := styles.NewStyle().Foreground(b.TextMuted()).Background(b.Background()).Render
 
 	open := ""
 
@@ -1014,18 +1014,19 @@ func (a Model) home() (string, int, int) {
 				out = append(out, "")
 				continue
 			}
-			var b strings.Builder
+			var sb strings.Builder
 			for x, r := range runes {
 				if r == ' ' {
-					b.WriteRune(' ')
+					sb.WriteRune(' ')
 					continue
 				}
 				idx := int(float64(x) / float64(max(w-1, 1)) * float64(len(colors)-1))
-				st := styles.NewStyle().Foreground(compat.AdaptiveColor{Dark: lipgloss.Color(colors[idx]), Light: lipgloss.Color(colors[idx])}).Background(t.Background())
-				b.WriteString(st.Render(string(r)))
+				st := styles.NewStyle().Foreground(compat.AdaptiveColor{Dark: lipgloss.Color(colors[idx]), Light: lipgloss.Color(colors[idx])}).Background(b.Background())
+				sb.WriteString(st.Render(string(r)))
 			}
-			out = append(out, b.String())
+			out = append(out, sb.String())
 		}
+
 		return strings.Join(out, "\n")
 	}
 
@@ -1038,8 +1039,8 @@ func (a Model) home() (string, int, int) {
 	// config := app.Info.Path.Config
 
 	versionStyle := styles.NewStyle().
-		Foreground(t.TextMuted()).
-		Background(t.Background()).
+		Foreground(b.TextMuted()).
+		Background(b.Background()).
 		Width(lipgloss.Width(logo)).
 		Align(lipgloss.Right)
 	version := versionStyle.Render(a.app.Version)
@@ -1049,7 +1050,7 @@ func (a Model) home() (string, int, int) {
 		effectiveWidth,
 		lipgloss.Center,
 		logoAndVersion,
-		styles.WhitespaceStyle(t.Background()),
+		styles.WhitespaceStyle(b.Background()),
 	)
 
 	// Use limit of 4 for vscode, 6 for others
@@ -1061,7 +1062,7 @@ func (a Model) home() (string, int, int) {
 	showVscode := util.IsVSCode()
 	commandsView := cmdcomp.New(
 		a.app,
-		cmdcomp.WithBackground(t.Background()),
+		cmdcomp.WithBackground(b.Background()),
 		cmdcomp.WithLimit(limit),
 		cmdcomp.WithVscode(showVscode),
 	)
@@ -1069,7 +1070,7 @@ func (a Model) home() (string, int, int) {
 		effectiveWidth,
 		lipgloss.Center,
 		commandsView.View(),
-		styles.WhitespaceStyle(t.Background()),
+		styles.WhitespaceStyle(b.Background()),
 	)
 
 	lines := []string{}
@@ -1088,8 +1089,11 @@ func (a Model) home() (string, int, int) {
 		effectiveWidth,
 		lipgloss.Center,
 		editorView,
-		styles.WhitespaceStyle(t.Background()),
+		styles.WhitespaceStyle(b.Background()),
 	)
+	lines = append(lines, editorView)
+
+	editorLines := a.editor.Lines()
 
 	mainLayout := lipgloss.Place(
 		effectiveWidth,
@@ -1097,22 +1101,18 @@ func (a Model) home() (string, int, int) {
 		lipgloss.Center,
 		lipgloss.Center,
 		baseStyle.Render(strings.Join(lines, "\n")),
-		styles.WhitespaceStyle(t.Background()),
+		styles.WhitespaceStyle(b.Background()),
 	)
 
 	editorX := max(0, (effectiveWidth-editorWidth)/2)
 	editorY := (a.height / 2) + (mainHeight / 2) - 3
 	editorYDelta := 3
 
-	// Compute editor lines and set cursor offset
-	editorLines := a.editor.Lines()
 	if editorLines > 1 {
 		editorYDelta = 2
-	}
-	// Overlay editor content only when multi-line to keep cursor baseline correct
-	if editorLines > 1 {
 		content := a.editor.Content()
 		editorHeight := lipgloss.Height(content)
+
 		if editorY+editorHeight > a.height {
 			difference := (editorY + editorHeight) - a.height
 			editorY -= difference
@@ -1132,7 +1132,7 @@ func (a Model) home() (string, int, int) {
 
 		mainLayout = layout.PlaceOverlay(
 			editorX,
-			editorY-overlayHeight+1,
+			editorY-overlayHeight+2,
 			overlay,
 			mainLayout,
 		)
@@ -1143,7 +1143,7 @@ func (a Model) home() (string, int, int) {
 
 func (a Model) chat() (string, int, int) {
 	effectiveWidth := a.width - 4
-	t := theme.CurrentTheme()
+	b := theme.CurrentTheme()
 	editorView := a.editor.View()
 	lines := a.editor.Lines()
 	messagesView := a.messages.View()
@@ -1154,7 +1154,7 @@ func (a Model) chat() (string, int, int) {
 		effectiveWidth,
 		lipgloss.Center,
 		editorView,
-		styles.WhitespaceStyle(t.Background()),
+		styles.WhitespaceStyle(b.Background()),
 	)
 
 	mainLayout := messagesView + "\n" + editorView


### PR DESCRIPTION
## Summary
- Anchor project IDs to git superproject (stable SHA‑1 of superproject worktree) so downstream/smarty, downstream/fixes, and main share one session bucket
- Add migrations to consolidate legacy per-repo IDs and import orphaned sessions (copy-only, non-destructive)
- TUI: correct caret/overlay alignment in home/chat; CLI: --continue picks most recent top-level session

## Why
Unifies session history across our downstreams and the main repo by using a single canonical project identity. Avoids disappearances caused by per-submodule IDs and makes --continue behave predictably.